### PR TITLE
Fix typo in load_method_response

### DIFF
--- a/flask_xmlrpcre/xmlrpcre.py
+++ b/flask_xmlrpcre/xmlrpcre.py
@@ -257,7 +257,7 @@ def load_method_response(response):
     try:
         return xmlrpclib.loads(response)[0][0]
     except Fault:
-        _, fault = sys.exec_info()[:2]
+        _, fault = sys.exc_info()[:2]
         return fault
 
 


### PR DESCRIPTION
sys.exec_info() -> sys.exc_info()