### PR TITLE
Add optional allow_none parameter to dump_method_call and XMLRPCTester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 
 # IDEs
 .ropeproject
+.idea


### PR DESCRIPTION
This change adds ability to pass `allow_none` parameter to `xmlrpc.client.dumps` function to allow dumping of `None` values. It may be useful when testing RPC methods receiving and returning None values.