### PR TITLE
Wrong import in the compatibility package

### DIFF
--- a/flaskext/xmlrpc.py
+++ b/flaskext/xmlrpc.py
@@ -3,4 +3,4 @@ import warnings
 warnings.warn("flaskext.xmlrpcre namespace is deprecated, please use flask_xmlrpcre namespace instead",
               DeprecationWarning)
 
-from flask_xmlrpcre import *
+from flask_xmlrpcre.xmlrpcre import *


### PR DESCRIPTION
The `import *` in the `flaskext` compatibility package is actually importing from the wrong module.