### PR TITLE
Improve the "namespace packages" situation

### DIFF
--- a/flask_xmlrpcre/__init__.py
+++ b/flask_xmlrpcre/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+from .xmlrpcre import *

--- a/flaskext/__init__.py
+++ b/flaskext/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     description='Adds support for creating XML-RPC APIs to Flask',
     long_description=__doc__,
     packages=['flask_xmlrpcre', 'flaskext'],
-    namespace_packages=['flaskext'],
     zip_safe=False,
     platforms='any',
     install_requires=[


### PR DESCRIPTION
Fixes: #8

The `flask_xmlrpcre` package was declared as a namespace package, which is not actually the case, only the `flaskext` package is.
To preserve the usage described in the docs, this changeset imports the contents of the `xmlrpcre` submodule into the main module.

This PR also contains a commit to use the new PEP 420 style of namespace packages, see https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages.